### PR TITLE
Add content provider registry, advertiser performance tracking, and impression tracking by day

### DIFF
--- a/contracts/ad-distribution.clar
+++ b/contracts/ad-distribution.clar
@@ -64,3 +64,83 @@
         modification-timestamp: uint
     }
 )
+
+;; Content provider registry
+(define-map AuthorizedContentProviders
+    { content-provider: principal }
+    {
+        authorization-status: bool,
+        quality-score: uint,
+        lifetime-revenue: uint,
+        registration-block: uint,
+        recent-activity-block: uint
+    }
+)
+
+;; Advertiser performance tracking
+(define-map AdvertiserPerformance
+    { advertiser: principal }
+    {
+        campaign-count: uint,
+        live-campaign-count: uint,
+        lifetime-spend: uint,
+        lifetime-impressions: uint,
+        engagement-rate: uint,
+        trust-score: uint,
+        most-recent-campaign: uint,
+        registration-block: uint
+    }
+)
+
+;; Impression tracking by time period
+(define-map ImpressionsByDay
+    { ad-id: uint, block-day: uint }
+    { impression-count: uint }
+)
+
+;; ========================================
+;; Utility Functions
+;; ========================================
+
+(define-private (compute-commission-amount (payment-amount uint))
+    (/ (* payment-amount (var-get system-fee-basis-points)) u10000)
+)
+
+(define-private (verify-admin-privileges)
+    (is-eq tx-sender (var-get admin-address))
+)
+
+(define-private (check-provider-eligibility (content-provider principal))
+    (match (map-get? AuthorizedContentProviders { content-provider: content-provider })
+        provider-record (get authorization-status provider-record)
+        false
+    )
+)
+
+(define-private (log-daily-impression (ad-id uint))
+    (let
+        (
+            (current-period (/ block-height u144))  ;; Approximately daily blocks
+            (period-data (default-to { impression-count: u0 }
+                (map-get? ImpressionsByDay { ad-id: ad-id, block-day: current-period })))
+        )
+        (map-set ImpressionsByDay
+            { ad-id: ad-id, block-day: current-period }
+            { impression-count: (+ u1 (get impression-count period-data)) }
+        )
+        true  ;; Return success flag
+    )
+)
+
+(define-private (verify-impression-availability (ad-id uint))
+    (let
+        (
+            (ad-data (unwrap-panic (map-get? AdCampaigns { ad-id: ad-id })))
+            (current-period (/ block-height u144))
+            (period-impressions (default-to { impression-count: u0 }
+                (map-get? ImpressionsByDay { ad-id: ad-id, block-day: current-period })))
+        )
+        (<= (get impression-count period-impressions) (get daily-impression-max ad-data))
+    )
+)
+


### PR DESCRIPTION

**Summary:**
This pull request introduces three significant additions to the decentralized ad distribution system:

1. **Content Provider Registry**: A new `AuthorizedContentProviders` map to store information about content providers, including their authorization status, quality score, lifetime revenue, and registration details.
  
2. **Advertiser Performance Tracking**: A new `AdvertiserPerformance` map to track metrics related to advertisers, such as campaign count, live campaigns, lifetime spend, impressions, engagement rate, and trust score.

3. **Impression Tracking by Day**: A new `ImpressionsByDay` map to track the number of impressions each ad campaign has accumulated on a daily basis, using block height as a time reference.

**Details of Changes:**
- **Content Provider Registry**:  
  - The `AuthorizedContentProviders` map contains records for each content provider. It tracks:
    - `authorization-status`: A boolean indicating if the provider is authorized.
    - `quality-score`: A score representing the content quality of the provider.
    - `lifetime-revenue`: Total revenue earned by the provider.
    - `registration-block`: The block at which the provider registered.
    - `recent-activity-block`: The block of the most recent activity of the provider.

- **Advertiser Performance**:  
  - The `AdvertiserPerformance` map stores key performance data for each advertiser:
    - `campaign-count`: The total number of campaigns launched by the advertiser.
    - `live-campaign-count`: The number of active campaigns the advertiser currently has.
    - `lifetime-spend`: The total amount spent by the advertiser across campaigns.
    - `lifetime-impressions`: The total number of impressions generated by the advertiser's campaigns.
    - `engagement-rate`: The engagement rate for the advertiser's campaigns.
    - `trust-score`: A score that tracks the advertiser’s reliability and reputation.
    - `most-recent-campaign`: The ID of the most recent campaign run by the advertiser.
    - `registration-block`: The block height at which the advertiser first registered.

- **Impression Tracking by Day**:  
  - The `ImpressionsByDay` map keeps track of the number of impressions recorded for each ad campaign on a daily basis. This is helpful for enforcing daily impression limits and for monitoring the performance of ads over time.

**Impact on Existing Code:**
- **New Functionality**: These additions provide critical functionality for tracking content provider and advertiser performance, as well as tracking daily impressions for ads. They enable more robust reporting and management for both content providers and advertisers.
- **No Breaking Changes**: These additions do not break existing functionality and provide new features that can be leveraged for better system management.

**Test Plan:**
- A test suite for the new `AuthorizedContentProviders`, `AdvertiserPerformance`, and `ImpressionsByDay` maps should be developed to ensure accurate tracking of content provider data, advertiser performance, and impressions.

**Type of Change:**
- **Add meaningful new Clarity contract functionality**: The new maps and tracking mechanisms provide critical new functionality for content providers and advertisers.

